### PR TITLE
Configure CI and fix clippy warnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - 'dependencies'
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - 'github actions'

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,27 @@
+name: Dependencies
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+      - 'releases/**'
+    paths:
+      - 'Cargo.toml'
+      - 'deny.toml'
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'deny.toml'
+  schedule:
+    - cron: '0 0 * * 0'
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  dependencies:
+    name: Check dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v3
+
+      - name: Check dependencies
+        uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,67 @@
+name: Main
+on:
+  push:
+    branches-ignore:
+      - 'releases/**'
+      - 'dependabot/**'
+    paths-ignore:
+      - '**.md'
+      - '.gitignore'
+      - '.github/dependabot.yml'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '.gitignore'
+      - '.github/dependabot.yml'
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  test:
+    name: Test
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v3
+
+      - name: Cache crates
+        uses: Swatinem/rust-cache@v1
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  clippy:
+    name: Clippy
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v3
+
+      - name: Cache crates
+        uses: Swatinem/rust-cache@v1
+
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --no-deps --all-features -- -D warnings
+
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v3
+
+      - name: Format
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ use standard_paths::*;
 use standard_paths::LocationType::*;
 
 fn main() {
-    let sp = StandardPaths::new_with_names("app", "org");
+    let sp = StandardPaths::new("app", "org");
     println!("App data location: {:?}", sp.writable_location(AppLocalDataLocation));
 }
 ```

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,21 @@
+[advisories]
+unmaintained = "deny"
+yanked = "deny"
+notice = "deny"
+
+[licenses]
+copyleft = "deny"
+allow-osi-fsf-free = "either"
+
+[[licenses.clarify]]
+name = "stretch"
+expression = "MIT"
+license-files = []
+
+[bans]
+multiple-versions = "allow"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/examples/find_executables.rs
+++ b/examples/find_executables.rs
@@ -1,8 +1,8 @@
 extern crate standard_paths;
 
+use standard_paths::*;
 use std::env;
 use std::process;
-use standard_paths::*;
 
 fn main() {
     let args = env::args().skip(1).collect::<Vec<_>>();
@@ -30,11 +30,16 @@ fn main() {
     for exe in args {
         let fexe = format!("{:>1$}", exe, ind);
         match StandardPaths::find_executable(exe.clone()) {
-            Some(paths) => println!("{}: \"{}\"", fexe, paths.iter()
-                                                        .map(|p| p.to_str().unwrap())
-                                                        .collect::<Vec<_>>()
-                                                        .join("\", \"")),
-            _ => println!("{}: not found", fexe)
+            Some(paths) => println!(
+                "{}: \"{}\"",
+                fexe,
+                paths
+                    .iter()
+                    .map(|p| p.to_str().unwrap())
+                    .collect::<Vec<_>>()
+                    .join("\", \"")
+            ),
+            _ => println!("{}: not found", fexe),
         }
     }
 }

--- a/examples/folderid_generator.rs
+++ b/examples/folderid_generator.rs
@@ -1,24 +1,34 @@
 fn main() {
-    let ids = vec![        
-        ("FOLDERID_Desktop",        "B4BFCC3A-DB2C-424C-B029-7FE99A87C641"), // DesktopLocation
-        ("FOLDERID_Documents",      "FDD39AD0-238F-46AF-ADB4-6C85480369C7"), // DocumentsLocation
-        ("FOLDERID_Fonts",          "FD228CB7-AE11-4AE3-864C-16F3910AB8FE"), // FontsLocation
-        ("FOLDERID_Programs",       "A77F5D77-2E2B-44C3-A6A2-ABA601054A51"), // ApplicationsLocation
-        ("FOLDERID_Music",          "4BD8D571-6D19-48D3-BE97-422220080E43"), // MusicLocation
-        ("FOLDERID_Videos",         "18989B1D-99B5-455B-841C-AB7C74E4DDFC"), // MoviesLocation
-        ("FOLDERID_Pictures",       "33E28130-4E1E-4676-835A-98395C3BC3BB"), // PicturesLocation
-        ("FOLDERID_Downloads",      "374DE290-123F-4565-9164-39C4925E467B"), // DownloadLocation
-        ("FOLDERID_LocalAppData",   "F1B32785-6FBA-4FCF-9D55-7B8E7F157091"), // AppLocalDataLocation, AppLocalDataLocation,
-                                                                             // GenericDataLocation, ConfigLocation,
-                                                                             // GenericConfigLocation, AppConfigLocation
-        ("FOLDERID_RoamingAppData", "3EB685DB-65F9-4CF6-A03A-E3EF65729F3D"), // AppDataLocation
-        ("FOLDERID_ProgramData",    "62AB5D82-FDC1-4DC3-A9DD-070D1D495D97")  // ConfigLocation, AppConfigLocation,
-                                                                             // AppDataLocation, AppLocalDataLocation,
-                                                                             // GenericConfigLocation, GenericDataLocation
+    let ids = vec![
+        ("FOLDERID_Desktop", "B4BFCC3A-DB2C-424C-B029-7FE99A87C641"), // DesktopLocation
+        ("FOLDERID_Documents", "FDD39AD0-238F-46AF-ADB4-6C85480369C7"), // DocumentsLocation
+        ("FOLDERID_Fonts", "FD228CB7-AE11-4AE3-864C-16F3910AB8FE"),   // FontsLocation
+        ("FOLDERID_Programs", "A77F5D77-2E2B-44C3-A6A2-ABA601054A51"), // ApplicationsLocation
+        ("FOLDERID_Music", "4BD8D571-6D19-48D3-BE97-422220080E43"),   // MusicLocation
+        ("FOLDERID_Videos", "18989B1D-99B5-455B-841C-AB7C74E4DDFC"),  // MoviesLocation
+        ("FOLDERID_Pictures", "33E28130-4E1E-4676-835A-98395C3BC3BB"), // PicturesLocation
+        ("FOLDERID_Downloads", "374DE290-123F-4565-9164-39C4925E467B"), // DownloadLocation
+        (
+            "FOLDERID_LocalAppData",
+            "F1B32785-6FBA-4FCF-9D55-7B8E7F157091",
+        ), // AppLocalDataLocation, AppLocalDataLocation,
+        // GenericDataLocation, ConfigLocation,
+        // GenericConfigLocation, AppConfigLocation
+        (
+            "FOLDERID_RoamingAppData",
+            "3EB685DB-65F9-4CF6-A03A-E3EF65729F3D",
+        ), // AppDataLocation
+        (
+            "FOLDERID_ProgramData",
+            "62AB5D82-FDC1-4DC3-A9DD-070D1D495D97",
+        ), // ConfigLocation, AppConfigLocation,
+           // AppDataLocation, AppLocalDataLocation,
+           // GenericConfigLocation, GenericDataLocation
     ];
 
     for &(name, guid) in &ids {
-        println!("\
+        println!(
+            "\
 /// https://msdn.microsoft.com/en-us/library/dd378457.aspx#{name}
 #[allow(non_upper_case_globals)]
 const {name}: GUID = GUID {{
@@ -27,17 +37,18 @@ const {name}: GUID = GUID {{
     Data3: 0x{},
     Data4: [0x{}, 0x{}, 0x{}, 0x{}, 0x{}, 0x{}, 0x{}, 0x{}]
 }};\n",
-                 guid.get(..8).unwrap(),
-                 guid.get(9..13).unwrap(),
-                 guid.get(14..18).unwrap(),
-                 guid.get(19..21).unwrap(),
-                 guid.get(21..23).unwrap(),
-                 guid.get(24..26).unwrap(),
-                 guid.get(26..28).unwrap(),
-                 guid.get(28..30).unwrap(),
-                 guid.get(30..32).unwrap(),
-                 guid.get(32..34).unwrap(),
-                 guid.get(34..36).unwrap(),
-                 name = name);
+            guid.get(..8).unwrap(),
+            guid.get(9..13).unwrap(),
+            guid.get(14..18).unwrap(),
+            guid.get(19..21).unwrap(),
+            guid.get(21..23).unwrap(),
+            guid.get(24..26).unwrap(),
+            guid.get(26..28).unwrap(),
+            guid.get(28..30).unwrap(),
+            guid.get(30..32).unwrap(),
+            guid.get(32..34).unwrap(),
+            guid.get(34..36).unwrap(),
+            name = name
+        );
     }
 }

--- a/examples/list_paths.rs
+++ b/examples/list_paths.rs
@@ -26,7 +26,7 @@ fn main() {
         ("App Config", AppConfigLocation),
     ];
 
-    let sl = StandardPaths::new_with_names("app", "org");
+    let sl = StandardPaths::new("app", "org");
 
     println!("\nListing standard locations:");
     for &(ref name, ref value) in &locations {

--- a/examples/list_paths.rs
+++ b/examples/list_paths.rs
@@ -1,42 +1,46 @@
 extern crate standard_paths;
 
-use standard_paths::*;
 use standard_paths::LocationType::*;
+use standard_paths::*;
 
 fn main() {
     let locations = vec![
-        ("Home",            HomeLocation),
-        ("Desktop",         DesktopLocation),
-        ("Documents",       DocumentsLocation),
-        ("Download",        DownloadLocation),
-        ("Movies",          MoviesLocation),
-        ("Music",           MusicLocation),
-        ("Pictures",        PicturesLocation),
-        ("Applications",    ApplicationsLocation),
-        ("Fonts",           FontsLocation),
-        ("Runtime",         RuntimeLocation),
-        ("Temp",            TempLocation),
-        ("Generic Data",    GenericDataLocation),
-        ("App Data",        AppDataLocation),
-        ("App Local Data",  AppLocalDataLocation),
-        ("Generic Cache",   GenericCacheLocation),
-        ("App Cache",       AppCacheLocation),
-        ("Config",          ConfigLocation),
-        ("Generic Config",  GenericConfigLocation),
-        ("App Config",      AppConfigLocation)
+        ("Home", HomeLocation),
+        ("Desktop", DesktopLocation),
+        ("Documents", DocumentsLocation),
+        ("Download", DownloadLocation),
+        ("Movies", MoviesLocation),
+        ("Music", MusicLocation),
+        ("Pictures", PicturesLocation),
+        ("Applications", ApplicationsLocation),
+        ("Fonts", FontsLocation),
+        ("Runtime", RuntimeLocation),
+        ("Temp", TempLocation),
+        ("Generic Data", GenericDataLocation),
+        ("App Data", AppDataLocation),
+        ("App Local Data", AppLocalDataLocation),
+        ("Generic Cache", GenericCacheLocation),
+        ("App Cache", AppCacheLocation),
+        ("Config", ConfigLocation),
+        ("Generic Config", GenericConfigLocation),
+        ("App Config", AppConfigLocation),
     ];
 
     let sl = StandardPaths::new_with_names("app", "org");
-    
+
     println!("\nListing standard locations:");
     for &(ref name, ref value) in &locations {
         match sl.standard_locations(value.clone()) {
-            Ok(paths) => println!("{:>14}: \"{}\"", name, paths.iter()
-                                                                .map(|p| p.to_str().unwrap())
-                                                                .collect::<Vec<_>>()
-                                                                .join("\", \"")
-                                                                ),
-            Err(err) => println!("{:>14}: {}", name, err)
+            Ok(paths) => println!(
+                "{:>14}: \"{}\"",
+                name,
+                paths
+                    .iter()
+                    .map(|p| p.to_str().unwrap())
+                    .collect::<Vec<_>>()
+                    .join("\", \"")
+            ),
+            Err(err) => println!("{:>14}: {}", name, err),
         }
     }
 
@@ -44,7 +48,7 @@ fn main() {
     for &(ref name, ref value) in &locations {
         match sl.writable_location(value.clone()) {
             Ok(path) => println!("{:>14}: \"{}\"", name, path.to_str().unwrap()),
-            Err(err) => println!("{:>14}: {}", name, err)
+            Err(err) => println!("{:>14}: {}", name, err),
         }
     }
 }

--- a/examples/locate.rs
+++ b/examples/locate.rs
@@ -84,7 +84,7 @@ fn main() {
         }
     };
 
-    let sp = StandardPaths::new_with_names(app_name, org_name);
+    let sp = StandardPaths::new(app_name, org_name);
     if locate_all {
         match sp.locate_all(location, &file, option) {
             Ok(paths) => {

--- a/examples/locate.rs
+++ b/examples/locate.rs
@@ -1,18 +1,18 @@
-extern crate standard_paths;
 extern crate argparse;
+extern crate standard_paths;
 
-use std::process;
-use standard_paths::*;
+use argparse::{ArgumentParser, Store, StoreTrue};
 use standard_paths::LocateOption::*;
 use standard_paths::LocationType::*;
-use argparse::{ArgumentParser, Store, StoreTrue};
+use standard_paths::*;
+use std::process;
 
 fn main() {
     let mut app_name = String::new();
     let mut org_name = String::new();
-    let mut file     = String::new();
+    let mut file = String::new();
     let mut location = String::new();
-    let mut option   = String::from("LocateFile");
+    let mut option = String::from("LocateFile");
     let mut locate_all = false;
     {
         let mut ap = ArgumentParser::new();
@@ -29,45 +29,57 @@ fn main() {
         ap.refer(&mut location)
             .add_argument("location", Store, "type of location")
             .required();
-        ap.refer(&mut option)
-            .add_option(&["-o", "--option"], Store, "locate option, default is 'LocateFile'");
-        ap.refer(&mut locate_all)
-            .add_option(&["-a", "--all"], StoreTrue, "locate all, default is false");
+        ap.refer(&mut option).add_option(
+            &["-o", "--option"],
+            Store,
+            "locate option, default is 'LocateFile'",
+        );
+        ap.refer(&mut locate_all).add_option(
+            &["-a", "--all"],
+            StoreTrue,
+            "locate all, default is false",
+        );
         ap.parse_args_or_exit();
     }
 
     let location = match location.as_str() {
-        "HomeLocation"          => HomeLocation,
-        "DesktopLocation"       => DesktopLocation,
-        "DocumentsLocation"     => DocumentsLocation,
-        "DownloadLocation"      => DownloadLocation,
-        "MoviesLocation"        => MoviesLocation,
-        "MusicLocation"         => MusicLocation,
-        "PicturesLocation"      => PicturesLocation,
-        "ApplicationsLocation"  => ApplicationsLocation,
-        "FontsLocation"         => FontsLocation,
-        "RuntimeLocation"       => RuntimeLocation,
-        "TempLocation"          => TempLocation,
-        "GenericDataLocation"   => GenericDataLocation,
-        "AppDataLocation"       => AppDataLocation,
-        "AppLocalDataLocation"  => AppLocalDataLocation,
-        "GenericCacheLocation"  => GenericCacheLocation,
-        "AppCacheLocation"      => AppCacheLocation,
-        "ConfigLocation"        => ConfigLocation,
+        "HomeLocation" => HomeLocation,
+        "DesktopLocation" => DesktopLocation,
+        "DocumentsLocation" => DocumentsLocation,
+        "DownloadLocation" => DownloadLocation,
+        "MoviesLocation" => MoviesLocation,
+        "MusicLocation" => MusicLocation,
+        "PicturesLocation" => PicturesLocation,
+        "ApplicationsLocation" => ApplicationsLocation,
+        "FontsLocation" => FontsLocation,
+        "RuntimeLocation" => RuntimeLocation,
+        "TempLocation" => TempLocation,
+        "GenericDataLocation" => GenericDataLocation,
+        "AppDataLocation" => AppDataLocation,
+        "AppLocalDataLocation" => AppLocalDataLocation,
+        "GenericCacheLocation" => GenericCacheLocation,
+        "AppCacheLocation" => AppCacheLocation,
+        "ConfigLocation" => ConfigLocation,
         "GenericConfigLocation" => GenericConfigLocation,
-        "AppConfigLocation"     => AppConfigLocation,
+        "AppConfigLocation" => AppConfigLocation,
         _ => {
-            eprintln!("Bad location type '{}', see the documentation for valid values", location);
+            eprintln!(
+                "Bad location type '{}', see the documentation for valid values",
+                location
+            );
             process::exit(1)
         }
     };
 
     let option = match option.as_str() {
-        "LocateBoth"      => LocateBoth,
-        "LocateFile"      => LocateFile,
+        "LocateBoth" => LocateBoth,
+        "LocateFile" => LocateFile,
         "LocateDirectory" => LocateDirectory,
         _ => {
-            eprintln!("Bad locate option '{}', see the documentation for valid values", option);
+            eprintln!(
+                "Bad locate option '{}', see the documentation for valid values",
+                option
+            );
             process::exit(1)
         }
     };
@@ -77,15 +89,18 @@ fn main() {
         match sp.locate_all(location, &file, option) {
             Ok(paths) => {
                 if paths.is_some() {
-                    println!("\"{}\"", paths
-                                            .unwrap()
-                                            .iter()
-                                            .map(|p| p.to_str().unwrap())
-                                            .collect::<Vec<_>>()
-                                            .join("\", \""));
+                    println!(
+                        "\"{}\"",
+                        paths
+                            .unwrap()
+                            .iter()
+                            .map(|p| p.to_str().unwrap())
+                            .collect::<Vec<_>>()
+                            .join("\", \"")
+                    );
                     process::exit(0)
                 }
-            },
+            }
             Err(err) => {
                 eprintln!("{}", err);
                 process::exit(2)
@@ -98,13 +113,13 @@ fn main() {
                     println!("\"{}\"", path.unwrap().to_str().unwrap());
                     process::exit(0)
                 }
-            },
+            }
             Err(err) => {
                 eprintln!("{}", err);
                 process::exit(2)
             }
         }
     }
-    
+
     println!("No entries found for '{}'", file);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,8 @@ mod windows;
 use windows::*;
 
 use std::env;
-use std::path::{Path, PathBuf};
 use std::io::{Error, ErrorKind};
-
+use std::path::{Path, PathBuf};
 
 /// Enumerates the standard location type.
 ///
@@ -122,7 +121,7 @@ pub enum LocationType {
     /// The user-specific configuration files directory.
     ///
     /// This is an application-specific value.
-    AppConfigLocation
+    AppConfigLocation,
 }
 
 /// Enumerates the locate option type.
@@ -137,7 +136,7 @@ pub enum LocateOption {
     /// Locate only files.
     LocateFile,
     /// Locate only directories.
-    LocateDirectory
+    LocateDirectory,
 }
 
 /// Stores application and organization names and provides all the crate methods.
@@ -145,29 +144,30 @@ pub struct StandardPaths {
     /// Application name.
     app_name: String,
     /// organization name.
-    org_name: String
+    org_name: String,
 }
 
 impl StandardPaths {
-
     /// Constructs a new `StandardPaths` with the application name
     /// derived from the `CARGO_PKG_NAME` variable.
     pub fn new() -> StandardPaths {
         StandardPaths {
             app_name: match env::var("CARGO_PKG_NAME") {
                 Ok(name) => name,
-                _ => String::new()
+                _ => String::new(),
             },
-            org_name: String::new()
+            org_name: String::new(),
         }
     }
 
     /// Constructs a new `StandardPaths` with the provided `app` and `organization` names.
     pub fn new_with_names<S>(app: S, organization: S) -> StandardPaths
-    where S: Into<String> {
+    where
+        S: Into<String>,
+    {
         StandardPaths {
             app_name: app.into(),
-            org_name: organization.into()
+            org_name: organization.into(),
         }
     }
 
@@ -234,11 +234,13 @@ impl StandardPaths {
     /// * `name` - the name of the searched executable or an absolute path
     /// which should be checked to be executable.
     pub fn find_executable<S>(name: S) -> Option<Vec<PathBuf>>
-    where S: Into<String> {
+    where
+        S: Into<String>,
+    {
         // Read system paths
         let path_var = match env::var("PATH") {
             Ok(var) => var,
-            _ => return None
+            _ => return None,
         };
         let paths: Vec<PathBuf> = env::split_paths(&path_var).collect();
         StandardPaths::find_executable_in_paths(name, paths)
@@ -257,7 +259,10 @@ impl StandardPaths {
     /// which should be checked to be executable.
     /// * `paths` - the directories where to search for the executable.
     pub fn find_executable_in_paths<S, P>(name: S, paths: P) -> Option<Vec<PathBuf>>
-    where S: Into<String>, P: AsRef<Vec<PathBuf>> {
+    where
+        S: Into<String>,
+        P: AsRef<Vec<PathBuf>>,
+    {
         find_executable_in_paths_impl(name, &paths)
     }
 
@@ -274,15 +279,34 @@ impl StandardPaths {
     /// * `location` - the location type where to search.
     /// * `name` - the name of the file or directory to search.
     /// * `option` - the type of entry to search.
-    pub fn locate<P>(&self, location: LocationType, name: P, option: LocateOption) -> Result<Option<PathBuf>, Error>
-    where P: AsRef<Path> {
+    pub fn locate<P>(
+        &self,
+        location: LocationType,
+        name: P,
+        option: LocateOption,
+    ) -> Result<Option<PathBuf>, Error>
+    where
+        P: AsRef<Path>,
+    {
         let paths = self.standard_locations(location)?;
         for mut path in paths {
             path.push(&name);
             match &option {
-                &LocateOption::LocateBoth => if path.exists() { return Ok(Some(path)) },
-                &LocateOption::LocateFile => if path.is_file() { return Ok(Some(path)) },
-                &LocateOption::LocateDirectory => if path.is_dir() { return Ok(Some(path)) }
+                &LocateOption::LocateBoth => {
+                    if path.exists() {
+                        return Ok(Some(path));
+                    }
+                }
+                &LocateOption::LocateFile => {
+                    if path.is_file() {
+                        return Ok(Some(path));
+                    }
+                }
+                &LocateOption::LocateDirectory => {
+                    if path.is_dir() {
+                        return Ok(Some(path));
+                    }
+                }
             }
         }
         Ok(None)
@@ -301,19 +325,42 @@ impl StandardPaths {
     /// * `location` - the location type where to search.
     /// * `name` - the name of the files or directories to search.
     /// * `option` - the type of entries to search.
-    pub fn locate_all<P>(&self, location: LocationType, name: P, option: LocateOption) -> Result<Option<Vec<PathBuf>>, Error>
-    where P: AsRef<Path> {
+    pub fn locate_all<P>(
+        &self,
+        location: LocationType,
+        name: P,
+        option: LocateOption,
+    ) -> Result<Option<Vec<PathBuf>>, Error>
+    where
+        P: AsRef<Path>,
+    {
         let paths = self.standard_locations(location)?;
         let mut res = Vec::new();
         for mut path in paths {
             path.push(&name);
             match &option {
-                &LocateOption::LocateBoth => if path.exists() { res.push(path); },
-                &LocateOption::LocateFile => if path.is_file() { res.push(path); },
-                &LocateOption::LocateDirectory => if path.is_dir() { res.push(path); }
+                &LocateOption::LocateBoth => {
+                    if path.exists() {
+                        res.push(path);
+                    }
+                }
+                &LocateOption::LocateFile => {
+                    if path.is_file() {
+                        res.push(path);
+                    }
+                }
+                &LocateOption::LocateDirectory => {
+                    if path.is_dir() {
+                        res.push(path);
+                    }
+                }
             }
         }
-        if res.is_empty() { Ok(None) } else { Ok(Some(res)) }
+        if res.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(res))
+        }
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,12 @@
 //! use standard_paths::LocationType::*;
 //!
 //! fn main() {
-//!     let sp = StandardPaths::new_with_names("app", "org");
+//!     let sp = StandardPaths::new("app", "org");
 //!     println!("{:?}", sp.writable_location(AppLocalDataLocation));
 //! }
 //! ```
+
+#![allow(deprecated)] // Do not warn about deprecated std::env::home_dir
 
 #[cfg(target_os = "linux")]
 mod linux;
@@ -147,10 +149,10 @@ pub struct StandardPaths {
     org_name: String,
 }
 
-impl StandardPaths {
+impl Default for StandardPaths {
     /// Constructs a new `StandardPaths` with the application name
     /// derived from the `CARGO_PKG_NAME` variable.
-    pub fn new() -> StandardPaths {
+    fn default() -> StandardPaths {
         StandardPaths {
             app_name: match env::var("CARGO_PKG_NAME") {
                 Ok(name) => name,
@@ -159,9 +161,11 @@ impl StandardPaths {
             org_name: String::new(),
         }
     }
+}
 
+impl StandardPaths {
     /// Constructs a new `StandardPaths` with the provided `app` and `organization` names.
-    pub fn new_with_names<S>(app: S, organization: S) -> StandardPaths
+    pub fn new<S>(app: S, organization: S) -> StandardPaths
     where
         S: Into<String>,
     {
@@ -291,18 +295,18 @@ impl StandardPaths {
         let paths = self.standard_locations(location)?;
         for mut path in paths {
             path.push(&name);
-            match &option {
-                &LocateOption::LocateBoth => {
+            match option {
+                LocateOption::LocateBoth => {
                     if path.exists() {
                         return Ok(Some(path));
                     }
                 }
-                &LocateOption::LocateFile => {
+                LocateOption::LocateFile => {
                     if path.is_file() {
                         return Ok(Some(path));
                     }
                 }
-                &LocateOption::LocateDirectory => {
+                LocateOption::LocateDirectory => {
                     if path.is_dir() {
                         return Ok(Some(path));
                     }
@@ -338,18 +342,18 @@ impl StandardPaths {
         let mut res = Vec::new();
         for mut path in paths {
             path.push(&name);
-            match &option {
-                &LocateOption::LocateBoth => {
+            match option {
+                LocateOption::LocateBoth => {
                     if path.exists() {
                         res.push(path);
                     }
                 }
-                &LocateOption::LocateFile => {
+                LocateOption::LocateFile => {
                     if path.is_file() {
                         res.push(path);
                     }
                 }
-                &LocateOption::LocateDirectory => {
+                LocateOption::LocateDirectory => {
                     if path.is_dir() {
                         res.push(path);
                     }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -26,7 +26,7 @@ macro_rules! get_var_or_home {
                 },
                 _ => return Err(StandardPaths::home_dir_err())
             }
-        };
+        }
     }
 }
 
@@ -70,7 +70,7 @@ impl StandardPaths {
     #[doc(hidden)]
     pub fn writable_location_impl(&self, location: LocationType) -> Result<PathBuf, Error> {
         match location {
-            LocationType::HomeLocation => env::home_dir().ok_or(StandardPaths::home_dir_err()),
+            LocationType::HomeLocation => env::home_dir().ok_or_else(StandardPaths::home_dir_err),
             LocationType::TempLocation => Ok(env::temp_dir()),
             LocationType::AppCacheLocation | LocationType::GenericCacheLocation => {
                 // http://standards.freedesktop.org/basedir-spec/basedir-spec-0.6.html
@@ -130,7 +130,7 @@ impl StandardPaths {
                         if !md.is_dir() {
                             fs::create_dir_all(&path)?;
                         }
-                        (PathBuf::from(path), md)
+                        (path, md)
                     }
                 };
 
@@ -290,7 +290,7 @@ where
     }
 }
 
-const EXTENSIONS: [&'static str; 3] = ["bin", "run", "sh"];
+const EXTENSIONS: [&str; 3] = ["bin", "run", "sh"];
 
 #[inline]
 #[doc(hidden)]
@@ -323,7 +323,7 @@ where
 
     // At first search the provided name
     let mut res = Vec::new();
-    for mut path in paths.to_owned() {
+    for mut path in paths.iter().cloned() {
         path.push(&name);
         if is_executable(&path) {
             res.push(path);
@@ -332,7 +332,7 @@ where
 
     // Then check if an extension could be appended
     if path.extension().is_none() {
-        for mut path in paths.to_owned() {
+        for mut path in paths.iter().cloned() {
             path.push(&name);
             for ext in &EXTENSIONS {
                 let mut full_path = path.clone();

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,21 +1,17 @@
 extern crate users;
 
-use std::path::PathBuf;
+use self::users::{get_current_uid, get_user_by_uid};
+use std::collections::HashMap;
 use std::env;
-use self::users::{
-    get_user_by_uid,
-    get_current_uid
-};
 use std::fs;
-use std::os::linux::fs::MetadataExt;
-use std::os::unix::fs::PermissionsExt;
 use std::io::prelude::*;
 use std::io::{BufReader, Error, ErrorKind};
-use std::collections::HashMap;
+use std::os::linux::fs::MetadataExt;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
 
-use ::LocationType;
-use ::StandardPaths;
-
+use LocationType;
+use StandardPaths;
 
 macro_rules! get_var_or_home {
     ($var_name:expr, $($sub_dirs:expr),*) => {
@@ -41,8 +37,8 @@ fn xdg_config_dirs() -> Vec<PathBuf> {
             let mut paths: Vec<PathBuf> = paths.split(':').map(PathBuf::from).collect();
             paths.dedup();
             paths
-        },
-        _ => vec!["/etc/xdg".into()]
+        }
+        _ => vec!["/etc/xdg".into()],
     }
 }
 
@@ -62,22 +58,17 @@ fn xdg_data_dirs() -> Vec<PathBuf> {
                 }
             }
             res
-        },
+        }
         _ => {
-            vec![
-                "/usr/local/share".into(),
-                "/usr/share".into()
-            ]
+            vec!["/usr/local/share".into(), "/usr/share".into()]
         }
     }
 }
 
 impl StandardPaths {
-
     #[inline]
     #[doc(hidden)]
     pub fn writable_location_impl(&self, location: LocationType) -> Result<PathBuf, Error> {
-
         match location {
             LocationType::HomeLocation => env::home_dir().ok_or(StandardPaths::home_dir_err()),
             LocationType::TempLocation => Ok(env::temp_dir()),
@@ -88,29 +79,30 @@ impl StandardPaths {
                     self.append_organization_and_app(&mut path);
                 }
                 Ok(path)
-            },
+            }
 
-            LocationType::AppDataLocation |
-            LocationType::AppLocalDataLocation |
-            LocationType::GenericDataLocation => {
+            LocationType::AppDataLocation
+            | LocationType::AppLocalDataLocation
+            | LocationType::GenericDataLocation => {
                 let mut path = get_var_or_home!("XDG_DATA_HOME", ".local", "share");
-                if location == LocationType::AppDataLocation ||
-                   location == LocationType::AppLocalDataLocation {
+                if location == LocationType::AppDataLocation
+                    || location == LocationType::AppLocalDataLocation
+                {
                     self.append_organization_and_app(&mut path);
                 }
                 Ok(path)
-            },
+            }
 
-            LocationType::ConfigLocation |
-            LocationType::GenericConfigLocation |
-            LocationType::AppConfigLocation => {
+            LocationType::ConfigLocation
+            | LocationType::GenericConfigLocation
+            | LocationType::AppConfigLocation => {
                 // http://standards.freedesktop.org/basedir-spec/latest/
                 let mut path = get_var_or_home!("XDG_CONFIG_HOME", ".config");
                 if location == LocationType::AppConfigLocation {
                     self.append_organization_and_app(&mut path);
                 }
                 Ok(path)
-            },
+            }
 
             LocationType::RuntimeLocation => {
                 // http://standards.freedesktop.org/basedir-spec/latest/
@@ -119,11 +111,16 @@ impl StandardPaths {
                     Ok(path) => {
                         let md = fs::metadata(&path)?;
                         if !md.is_dir() {
-                            return Err(Error::new(ErrorKind::Other,
-                                format!("'XDG_RUNTIME_DIR' points to '{}' which is not a directory", path)))
+                            return Err(Error::new(
+                                ErrorKind::Other,
+                                format!(
+                                    "'XDG_RUNTIME_DIR' points to '{}' which is not a directory",
+                                    path
+                                ),
+                            ));
                         }
                         (PathBuf::from(path), md)
-                    },
+                    }
                     _ => {
                         let mut runtime_dir = String::from("runtime-");
                         runtime_dir.push_str(&user.name().to_string_lossy());
@@ -139,9 +136,15 @@ impl StandardPaths {
 
                 // The directory MUST be owned by the user
                 if md.st_uid() != user.uid() {
-                    return Err(Error::new(ErrorKind::PermissionDenied,
-                        format!("Wrong ownership on runtime directory '{}' - {} instead of {}",
-                                path.to_str().unwrap(), md.st_uid(), user.uid())))
+                    return Err(Error::new(
+                        ErrorKind::PermissionDenied,
+                        format!(
+                            "Wrong ownership on runtime directory '{}' - {} instead of {}",
+                            path.to_str().unwrap(),
+                            md.st_uid(),
+                            user.uid()
+                        ),
+                    ));
                 }
                 // And its Unix access mode MUST be 0700.
                 let mut permissions = md.permissions();
@@ -150,7 +153,7 @@ impl StandardPaths {
                 }
 
                 Ok(path)
-            },
+            }
 
             LocationType::FontsLocation | LocationType::ApplicationsLocation => {
                 let dir = if location == LocationType::FontsLocation {
@@ -161,7 +164,7 @@ impl StandardPaths {
                 let mut path = self.writable_location_impl(LocationType::GenericDataLocation)?;
                 path.push(dir);
                 Ok(path)
-            },
+            }
 
             _ => {
                 // http://www.freedesktop.org/wiki/Software/xdg-user-dirs
@@ -177,8 +180,7 @@ impl StandardPaths {
                         let key = parts[0];
                         let key = parts[0].get(4..key.len() - 4).unwrap();
                         let mut value = parts[1];
-                        if value.len() > 2 &&
-                           value.starts_with('"') && value.ends_with('"') {
+                        if value.len() > 2 && value.starts_with('"') && value.ends_with('"') {
                             value = value.get(1..value.len() - 1).unwrap();
                         }
                         lines.insert(key.to_string(), value.to_string());
@@ -186,40 +188,40 @@ impl StandardPaths {
                 }
 
                 let key = match location {
-                    LocationType::DesktopLocation   => "DESKTOP",
+                    LocationType::DesktopLocation => "DESKTOP",
                     LocationType::DocumentsLocation => "DOCUMENTS",
-                    LocationType::PicturesLocation  => "PICTURES",
-                    LocationType::MusicLocation     => "MUSIC",
-                    LocationType::MoviesLocation    => "VIDEOS",
-                    LocationType::DownloadLocation  => "DOWNLOAD",
-                    _ => ""
+                    LocationType::PicturesLocation => "PICTURES",
+                    LocationType::MusicLocation => "MUSIC",
+                    LocationType::MoviesLocation => "VIDEOS",
+                    LocationType::DownloadLocation => "DOWNLOAD",
+                    _ => "",
                 };
                 if lines.contains_key(key) {
                     let value = &lines[key];
                     if value.starts_with("$HOME") {
                         let mut path = match env::home_dir() {
                             Some(path) => path,
-                            _ => return Err(StandardPaths::home_dir_err())
+                            _ => return Err(StandardPaths::home_dir_err()),
                         };
                         let value = value.get(6..).unwrap();
                         path.push(value);
-                        return Ok(path)
+                        return Ok(path);
                     }
-                    return Ok(value.into())
+                    return Ok(value.into());
                 }
 
                 let dir = match location {
-                    LocationType::DesktopLocation   => "Desktop",
+                    LocationType::DesktopLocation => "Desktop",
                     LocationType::DocumentsLocation => "Documents",
-                    LocationType::PicturesLocation  => "Pictures",
-                    LocationType::MusicLocation     => "Music",
-                    LocationType::MoviesLocation    => "Videos",
-                    LocationType::DownloadLocation  => "Downloads",
-                    _ => return Err(Error::new(ErrorKind::Other, "Unexpected error"))
+                    LocationType::PicturesLocation => "Pictures",
+                    LocationType::MusicLocation => "Music",
+                    LocationType::MoviesLocation => "Videos",
+                    LocationType::DownloadLocation => "Downloads",
+                    _ => return Err(Error::new(ErrorKind::Other, "Unexpected error")),
                 };
                 let mut path = match env::home_dir() {
                     Some(path) => path,
-                    _ => return Err(StandardPaths::home_dir_err())
+                    _ => return Err(StandardPaths::home_dir_err()),
                 };
                 path.push(dir);
                 Ok(path)
@@ -231,16 +233,14 @@ impl StandardPaths {
     #[doc(hidden)]
     pub fn standard_locations_impl(&self, location: LocationType) -> Result<Vec<PathBuf>, Error> {
         let mut res: Vec<PathBuf> = match location {
-
-            LocationType::ConfigLocation |
-            LocationType::GenericConfigLocation => xdg_config_dirs(),
+            LocationType::ConfigLocation | LocationType::GenericConfigLocation => xdg_config_dirs(),
             LocationType::AppConfigLocation => {
                 let mut dirs = xdg_config_dirs();
                 for dir in dirs.iter_mut() {
                     self.append_organization_and_app(dir);
                 }
                 dirs
-            },
+            }
 
             LocationType::GenericDataLocation => xdg_data_dirs(),
 
@@ -250,26 +250,25 @@ impl StandardPaths {
                     dir.push("applications");
                 }
                 dirs
-            },
+            }
 
-            LocationType::AppDataLocation |
-            LocationType::AppLocalDataLocation => {
+            LocationType::AppDataLocation | LocationType::AppLocalDataLocation => {
                 let mut dirs = xdg_data_dirs();
                 for dir in dirs.iter_mut() {
                     self.append_organization_and_app(dir);
                 }
                 dirs
-            },
+            }
 
             LocationType::FontsLocation => match env::home_dir() {
                 Some(mut path) => {
                     path.push(".fonts");
                     vec![path]
-                },
-                _ => return Err(StandardPaths::home_dir_err())
+                }
+                _ => return Err(StandardPaths::home_dir_err()),
             },
 
-            _ => Vec::new()
+            _ => Vec::new(),
         };
 
         let path = self.writable_location_impl(location)?;
@@ -280,11 +279,14 @@ impl StandardPaths {
 }
 
 /// Detect if `path` is an executable based on its rights
-pub fn is_executable<P>(path: P) -> bool where P: Into<PathBuf> {
+pub fn is_executable<P>(path: P) -> bool
+where
+    P: Into<PathBuf>,
+{
     let path = path.into();
     match fs::metadata(&path) {
         Ok(md) => md.permissions().mode() & 0o111 != 0,
-        _ => false
+        _ => false,
     }
 }
 
@@ -293,13 +295,16 @@ const EXTENSIONS: [&'static str; 3] = ["bin", "run", "sh"];
 #[inline]
 #[doc(hidden)]
 pub fn find_executable_in_paths_impl<S, P>(name: S, paths: P) -> Option<Vec<PathBuf>>
-where S: Into<String>, P: AsRef<Vec<PathBuf>> {
+where
+    S: Into<String>,
+    P: AsRef<Vec<PathBuf>>,
+{
     let name = name.into();
     let path = PathBuf::from(&name);
 
     // Check absolute paths
     if path.is_absolute() && is_executable(&name) {
-        return Some(vec![path])
+        return Some(vec![path]);
     }
 
     // Check paths
@@ -339,5 +344,9 @@ where S: Into<String>, P: AsRef<Vec<PathBuf>> {
         }
     }
 
-    if res.is_empty() { None } else { Some(res) }
+    if res.is_empty() {
+        None
+    } else {
+        Some(res)
+    }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,24 +1,23 @@
 extern crate winapi;
 
-use std::path::PathBuf;
 use std::env;
+use std::ffi::{OsStr, OsString};
+use std::io::{Error, ErrorKind};
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
+use std::path::PathBuf;
 use std::ptr;
 use std::slice;
-use std::ffi::{OsStr, OsString};
-use std::os::windows::ffi::{OsStrExt, OsStringExt};
-use std::io::{Error, ErrorKind};
 
 use self::winapi::shared::guiddef::GUID;
-use self::winapi::um::winnt::PWSTR;
+use self::winapi::shared::minwindef::DWORD;
 use self::winapi::um::combaseapi::CoTaskMemFree;
 use self::winapi::um::shlobj::SHGetKnownFolderPath;
-use self::winapi::shared::minwindef::DWORD;
 use self::winapi::um::winbase::GetBinaryTypeW;
+use self::winapi::um::winnt::PWSTR;
 
-use ::LocationType;
-use ::LocationType::*;
-use ::StandardPaths;
-
+use LocationType;
+use LocationType::*;
+use StandardPaths;
 
 /// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Desktop
 #[allow(non_upper_case_globals)]
@@ -26,7 +25,7 @@ const FOLDERID_Desktop: GUID = GUID {
     Data1: 0xB4BFCC3A,
     Data2: 0xDB2C,
     Data3: 0x424C,
-    Data4: [0xB0, 0x29, 0x7F, 0xE9, 0x9A, 0x87, 0xC6, 0x41]
+    Data4: [0xB0, 0x29, 0x7F, 0xE9, 0x9A, 0x87, 0xC6, 0x41],
 };
 
 /// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Documents
@@ -35,7 +34,7 @@ const FOLDERID_Documents: GUID = GUID {
     Data1: 0xFDD39AD0,
     Data2: 0x238F,
     Data3: 0x46AF,
-    Data4: [0xAD, 0xB4, 0x6C, 0x85, 0x48, 0x03, 0x69, 0xC7]
+    Data4: [0xAD, 0xB4, 0x6C, 0x85, 0x48, 0x03, 0x69, 0xC7],
 };
 
 /// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Fonts
@@ -44,7 +43,7 @@ const FOLDERID_Fonts: GUID = GUID {
     Data1: 0xFD228CB7,
     Data2: 0xAE11,
     Data3: 0x4AE3,
-    Data4: [0x86, 0x4C, 0x16, 0xF3, 0x91, 0x0A, 0xB8, 0xFE]
+    Data4: [0x86, 0x4C, 0x16, 0xF3, 0x91, 0x0A, 0xB8, 0xFE],
 };
 
 /// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Programs
@@ -53,7 +52,7 @@ const FOLDERID_Programs: GUID = GUID {
     Data1: 0xA77F5D77,
     Data2: 0x2E2B,
     Data3: 0x44C3,
-    Data4: [0xA6, 0xA2, 0xAB, 0xA6, 0x01, 0x05, 0x4A, 0x51]
+    Data4: [0xA6, 0xA2, 0xAB, 0xA6, 0x01, 0x05, 0x4A, 0x51],
 };
 
 /// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Music
@@ -62,7 +61,7 @@ const FOLDERID_Music: GUID = GUID {
     Data1: 0x4BD8D571,
     Data2: 0x6D19,
     Data3: 0x48D3,
-    Data4: [0xBE, 0x97, 0x42, 0x22, 0x20, 0x08, 0x0E, 0x43]
+    Data4: [0xBE, 0x97, 0x42, 0x22, 0x20, 0x08, 0x0E, 0x43],
 };
 
 /// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Videos
@@ -71,7 +70,7 @@ const FOLDERID_Videos: GUID = GUID {
     Data1: 0x18989B1D,
     Data2: 0x99B5,
     Data3: 0x455B,
-    Data4: [0x84, 0x1C, 0xAB, 0x7C, 0x74, 0xE4, 0xDD, 0xFC]
+    Data4: [0x84, 0x1C, 0xAB, 0x7C, 0x74, 0xE4, 0xDD, 0xFC],
 };
 
 /// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Pictures
@@ -80,7 +79,7 @@ const FOLDERID_Pictures: GUID = GUID {
     Data1: 0x33E28130,
     Data2: 0x4E1E,
     Data3: 0x4676,
-    Data4: [0x83, 0x5A, 0x98, 0x39, 0x5C, 0x3B, 0xC3, 0xBB]
+    Data4: [0x83, 0x5A, 0x98, 0x39, 0x5C, 0x3B, 0xC3, 0xBB],
 };
 
 /// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Downloads
@@ -89,7 +88,7 @@ const FOLDERID_Downloads: GUID = GUID {
     Data1: 0x374DE290,
     Data2: 0x123F,
     Data3: 0x4565,
-    Data4: [0x91, 0x64, 0x39, 0xC4, 0x92, 0x5E, 0x46, 0x7B]
+    Data4: [0x91, 0x64, 0x39, 0xC4, 0x92, 0x5E, 0x46, 0x7B],
 };
 
 /// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_LocalAppData
@@ -98,7 +97,7 @@ const FOLDERID_LocalAppData: GUID = GUID {
     Data1: 0xF1B32785,
     Data2: 0x6FBA,
     Data3: 0x4FCF,
-    Data4: [0x9D, 0x55, 0x7B, 0x8E, 0x7F, 0x15, 0x70, 0x91]
+    Data4: [0x9D, 0x55, 0x7B, 0x8E, 0x7F, 0x15, 0x70, 0x91],
 };
 
 /// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_RoamingAppData
@@ -107,7 +106,7 @@ const FOLDERID_RoamingAppData: GUID = GUID {
     Data1: 0x3EB685DB,
     Data2: 0x65F9,
     Data3: 0x4CF6,
-    Data4: [0xA0, 0x3A, 0xE3, 0xEF, 0x65, 0x72, 0x9F, 0x3D]
+    Data4: [0xA0, 0x3A, 0xE3, 0xEF, 0x65, 0x72, 0x9F, 0x3D],
 };
 
 /// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_ProgramData
@@ -116,7 +115,7 @@ const FOLDERID_ProgramData: GUID = GUID {
     Data1: 0x62AB5D82,
     Data2: 0xFDC1,
     Data3: 0x4DC3,
-    Data4: [0xA9, 0xDD, 0x07, 0x0D, 0x1D, 0x49, 0x5D, 0x97]
+    Data4: [0xA9, 0xDD, 0x07, 0x0D, 0x1D, 0x49, 0x5D, 0x97],
 };
 
 struct SafePwstr(PWSTR);
@@ -173,63 +172,75 @@ macro_rules! sh_get_known_folder_path {
 }
 
 impl StandardPaths {
-
     #[inline]
     #[doc(hidden)]
     pub fn writable_location_impl(&self, location: LocationType) -> Result<PathBuf, Error> {
         match location {
-
             DownloadLocation => {
-                sh_get_known_folder_path!(FOLDERID_Downloads, path, {
-                    Ok(path)
-                }, {
+                sh_get_known_folder_path!(FOLDERID_Downloads, path, { Ok(path) }, {
                     self.writable_location(DocumentsLocation)
                 })
-            },
+            }
 
             AppCacheLocation | GenericCacheLocation => {
                 // FOLDERID_InternetCache points to IE's cache. Most applications seem to
                 // be using a cache directory located in their AppData directory.
-                let loc2 = if location == AppCacheLocation { AppLocalDataLocation } else { GenericDataLocation };
+                let loc2 = if location == AppCacheLocation {
+                    AppLocalDataLocation
+                } else {
+                    GenericDataLocation
+                };
                 let mut path = self.writable_location(loc2)?;
                 path.push("cache");
                 Ok(path)
-            },
+            }
 
             RuntimeLocation | HomeLocation => env::home_dir().ok_or(StandardPaths::home_dir_err()),
 
             TempLocation => {
                 let canonicalized = env::temp_dir().canonicalize().unwrap();
-                Ok(PathBuf::from(canonicalized.to_str().unwrap().get(4..).unwrap()))
-            },
+                Ok(PathBuf::from(
+                    canonicalized.to_str().unwrap().get(4..).unwrap(),
+                ))
+            }
 
             _ => {
                 let id = match location {
-                    DesktopLocation       => FOLDERID_Desktop,
-                    DocumentsLocation     => FOLDERID_Documents,
-                    FontsLocation         => FOLDERID_Fonts,
-                    ApplicationsLocation  => FOLDERID_Programs,
-                    MusicLocation         => FOLDERID_Music,
-                    MoviesLocation        => FOLDERID_Videos,
-                    PicturesLocation      => FOLDERID_Pictures,
-                    AppLocalDataLocation | GenericDataLocation |
-                        ConfigLocation   | GenericConfigLocation |
-                        AppConfigLocation => FOLDERID_LocalAppData,
-                    AppDataLocation       => FOLDERID_RoamingAppData,
+                    DesktopLocation => FOLDERID_Desktop,
+                    DocumentsLocation => FOLDERID_Documents,
+                    FontsLocation => FOLDERID_Fonts,
+                    ApplicationsLocation => FOLDERID_Programs,
+                    MusicLocation => FOLDERID_Music,
+                    MoviesLocation => FOLDERID_Videos,
+                    PicturesLocation => FOLDERID_Pictures,
+                    AppLocalDataLocation
+                    | GenericDataLocation
+                    | ConfigLocation
+                    | GenericConfigLocation
+                    | AppConfigLocation => FOLDERID_LocalAppData,
+                    AppDataLocation => FOLDERID_RoamingAppData,
                     _ => GUID {
-                        Data1: 0x0, Data2: 0x0, Data3: 0x0,
-                        Data4: [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0]
-                    }
+                        Data1: 0x0,
+                        Data2: 0x0,
+                        Data3: 0x0,
+                        Data4: [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0],
+                    },
                 };
-                sh_get_known_folder_path!(id, mut path, {
-                    if location == ConfigLocation  || location == AppConfigLocation ||
-                       location == AppDataLocation || location == AppLocalDataLocation {
-                        self.append_organization_and_app(&mut path);
-                    }
-                    Ok(path)
-                }, {
-                    Err(Error::new(ErrorKind::Other, "Unexpected error"))
-                })
+                sh_get_known_folder_path!(
+                    id,
+                    mut path,
+                    {
+                        if location == ConfigLocation
+                            || location == AppConfigLocation
+                            || location == AppDataLocation
+                            || location == AppLocalDataLocation
+                        {
+                            self.append_organization_and_app(&mut path);
+                        }
+                        Ok(path)
+                    },
+                    { Err(Error::new(ErrorKind::Other, "Unexpected error")) }
+                )
             }
         }
     }
@@ -240,15 +251,24 @@ impl StandardPaths {
         let mut dirs = Vec::new();
         let path = self.writable_location(location.clone())?;
         dirs.push(path);
-        if location == ConfigLocation  || location == AppConfigLocation ||
-           location == AppDataLocation || location == AppLocalDataLocation ||
-           location == GenericConfigLocation || location == GenericDataLocation {
-            sh_get_known_folder_path!(FOLDERID_ProgramData, mut path, {
-                if location != GenericConfigLocation && location != GenericDataLocation {
-                    self.append_organization_and_app(&mut path);
-                }
-                dirs.push(path);
-            }, {});
+        if location == ConfigLocation
+            || location == AppConfigLocation
+            || location == AppDataLocation
+            || location == AppLocalDataLocation
+            || location == GenericConfigLocation
+            || location == GenericDataLocation
+        {
+            sh_get_known_folder_path!(
+                FOLDERID_ProgramData,
+                mut path,
+                {
+                    if location != GenericConfigLocation && location != GenericDataLocation {
+                        self.append_organization_and_app(&mut path);
+                    }
+                    dirs.push(path);
+                },
+                {}
+            );
             let path = env::current_exe()?;
             match path.parent() {
                 Some(parent) => {
@@ -256,8 +276,8 @@ impl StandardPaths {
                     dirs.push(parent.clone());
                     parent.push("data");
                     dirs.push(parent);
-                },
-                _ => ()
+                }
+                _ => (),
             }
         }
         Ok(dirs)
@@ -266,9 +286,16 @@ impl StandardPaths {
 
 /// Detect if `path` is an executable (based on
 /// [GetBinaryType](https://msdn.microsoft.com/ru-ru/library/windows/desktop/aa364819.aspx)).
-fn is_executable<P>(path: P) -> bool where P: AsRef<OsStr> {
+fn is_executable<P>(path: P) -> bool
+where
+    P: AsRef<OsStr>,
+{
     unsafe {
-        let name = path.as_ref().encode_wide().chain(Some(0)).collect::<Vec<_>>();
+        let name = path
+            .as_ref()
+            .encode_wide()
+            .chain(Some(0))
+            .collect::<Vec<_>>();
         let mut bt: DWORD = 0;
         GetBinaryTypeW(name.as_ptr(), &mut bt) != 0
     }
@@ -277,7 +304,10 @@ fn is_executable<P>(path: P) -> bool where P: AsRef<OsStr> {
 #[inline]
 #[doc(hidden)]
 pub fn find_executable_in_paths_impl<S, P>(name: S, paths: P) -> Option<Vec<PathBuf>>
-where S: Into<String>, P: AsRef<Vec<PathBuf>> {
+where
+    S: Into<String>,
+    P: AsRef<Vec<PathBuf>>,
+{
     let name = name.into();
     let path = PathBuf::from(&name);
 
@@ -285,24 +315,26 @@ where S: Into<String>, P: AsRef<Vec<PathBuf>> {
     // append suffixes from PATHEXT. If %PATHEXT% does not contain .exe, it is either empty or distorted.
     let mut exe_extensions = match env::var("PATHEXT") {
         Ok(pathext) => env::split_paths(&pathext)
-            .map(|e| e.to_str().unwrap().to_lowercase().get(1..).unwrap().to_string())
+            .map(|e| {
+                e.to_str()
+                    .unwrap()
+                    .to_lowercase()
+                    .get(1..)
+                    .unwrap()
+                    .to_string()
+            })
             .collect(),
-        _ => Vec::new()
+        _ => Vec::new(),
     };
     let exe = "exe".into();
     if exe_extensions.is_empty() || !exe_extensions.contains(&exe) {
-        exe_extensions = vec![
-            exe,
-            "com".into(),
-            "bat".into(),
-            "cmd".into()
-        ];
+        exe_extensions = vec![exe, "com".into(), "bat".into(), "cmd".into()];
     }
 
     // Check absolute paths
     if path.is_absolute() {
         if is_executable(&name) {
-            return Some(vec![path])
+            return Some(vec![path]);
         } else {
             let mut res = Vec::new();
             for ext in &exe_extensions {
@@ -312,7 +344,7 @@ where S: Into<String>, P: AsRef<Vec<PathBuf>> {
                     res.push(full_path);
                 }
             }
-            return if res.is_empty() { None } else { Some(res) }
+            return if res.is_empty() { None } else { Some(res) };
         }
     }
 
@@ -355,5 +387,9 @@ where S: Into<String>, P: AsRef<Vec<PathBuf>> {
         }
     }
 
-    if res.is_empty() { None } else { Some(res) }
+    if res.is_empty() {
+        None
+    } else {
+        Some(res)
+    }
 }


### PR DESCRIPTION
I set up dependabot (to automatically update dependencies), [cargo deny](https://github.com/EmbarkStudios/cargo-deny) (to check dependencies for vulnerabilities and license compatibility), formatting, tests and clippy checks.
Also I fixed discovered warnings (all changes was done only to silence warnings), applied formatting (I left only deprecated `std::env::home_dir()` function, probably should be replaced with [dirs-rs](https://github.com/dirs-dev/dirs-rs)) to make CI pass.

**Note:** I had to replace `new` with `default` and `new_with_names` with just `new` due to [this](https://rust-lang.github.io/rust-clippy/master/#new_without_default) warning. And I think this actually makes sense :)