### PR TITLE
Refactoring

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --no-deps --all-features -- -D warnings
+          args: --no-deps --examples -- -D warnings
 
   format:
     name: Format

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ categories = ["filesystem"]
 license = "MIT"
 readme = "README.md"
 
+[dependencies]
+home = "0.5"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 users = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "standard_paths"
 description = "A port of QStandardPaths class which provides methods for accessing standard paths on the local filesystem (config, cache, user directories and etc.)."
 version = "1.0.0"
+edition = "2021"
 authors = ["Petr Tsymbarovich <petr@tsymbarovich.ru>"]
 repository = "https://github.com/mentaljam/standard_paths"
 documentation = "https://docs.rs/standard_paths"

--- a/examples/find_executables.rs
+++ b/examples/find_executables.rs
@@ -6,7 +6,7 @@ use std::process;
 
 fn main() {
     let args = env::args().skip(1).collect::<Vec<_>>();
-    if args.len() == 0 {
+    if args.is_empty() {
         println!("\n    Usage: find_executable <path1> [path2 [path3 ...]]\n");
         process::exit(0);
     }

--- a/examples/find_executables.rs
+++ b/examples/find_executables.rs
@@ -1,8 +1,6 @@
-extern crate standard_paths;
+use std::{env, process};
 
 use standard_paths::*;
-use std::env;
-use std::process;
 
 fn main() {
     let args = env::args().skip(1).collect::<Vec<_>>();

--- a/examples/folderid_generator.rs
+++ b/examples/folderid_generator.rs
@@ -8,22 +8,25 @@ fn main() {
         ("FOLDERID_Videos", "18989B1D-99B5-455B-841C-AB7C74E4DDFC"),  // MoviesLocation
         ("FOLDERID_Pictures", "33E28130-4E1E-4676-835A-98395C3BC3BB"), // PicturesLocation
         ("FOLDERID_Downloads", "374DE290-123F-4565-9164-39C4925E467B"), // DownloadLocation
-        (
-            "FOLDERID_LocalAppData",
-            "F1B32785-6FBA-4FCF-9D55-7B8E7F157091",
-        ), // AppLocalDataLocation, AppLocalDataLocation,
+        // AppLocalDataLocation, AppLocalDataLocation,
         // GenericDataLocation, ConfigLocation,
         // GenericConfigLocation, AppConfigLocation
         (
+            "FOLDERID_LocalAppData",
+            "F1B32785-6FBA-4FCF-9D55-7B8E7F157091",
+        ),
+        // AppDataLocation
+        (
             "FOLDERID_RoamingAppData",
             "3EB685DB-65F9-4CF6-A03A-E3EF65729F3D",
-        ), // AppDataLocation
+        ),
+        // ConfigLocation, AppConfigLocation,
+        // AppDataLocation, AppLocalDataLocation,
+        // GenericConfigLocation, GenericDataLocation
         (
             "FOLDERID_ProgramData",
             "62AB5D82-FDC1-4DC3-A9DD-070D1D495D97",
-        ), // ConfigLocation, AppConfigLocation,
-           // AppDataLocation, AppLocalDataLocation,
-           // GenericConfigLocation, GenericDataLocation
+        ),
     ];
 
     for &(name, guid) in &ids {

--- a/examples/list_paths.rs
+++ b/examples/list_paths.rs
@@ -29,8 +29,8 @@ fn main() {
     let sl = StandardPaths::new("app", "org");
 
     println!("\nListing standard locations:");
-    for &(ref name, ref value) in &locations {
-        match sl.standard_locations(value.clone()) {
+    for (name, value) in &locations {
+        match sl.standard_locations(*value) {
             Ok(paths) => println!(
                 "{:>14}: \"{}\"",
                 name,
@@ -45,8 +45,8 @@ fn main() {
     }
 
     println!("\nListing writable locations:");
-    for &(ref name, ref value) in &locations {
-        match sl.writable_location(value.clone()) {
+    for (name, value) in &locations {
+        match sl.writable_location(*value) {
             Ok(path) => println!("{:>14}: \"{}\"", name, path.to_str().unwrap()),
             Err(err) => println!("{:>14}: {}", name, err),
         }

--- a/examples/list_paths.rs
+++ b/examples/list_paths.rs
@@ -1,29 +1,26 @@
-extern crate standard_paths;
-
-use standard_paths::LocationType::*;
 use standard_paths::*;
 
 fn main() {
     let locations = vec![
-        ("Home", HomeLocation),
-        ("Desktop", DesktopLocation),
-        ("Documents", DocumentsLocation),
-        ("Download", DownloadLocation),
-        ("Movies", MoviesLocation),
-        ("Music", MusicLocation),
-        ("Pictures", PicturesLocation),
-        ("Applications", ApplicationsLocation),
-        ("Fonts", FontsLocation),
-        ("Runtime", RuntimeLocation),
-        ("Temp", TempLocation),
-        ("Generic Data", GenericDataLocation),
-        ("App Data", AppDataLocation),
-        ("App Local Data", AppLocalDataLocation),
-        ("Generic Cache", GenericCacheLocation),
-        ("App Cache", AppCacheLocation),
-        ("Config", ConfigLocation),
-        ("Generic Config", GenericConfigLocation),
-        ("App Config", AppConfigLocation),
+        ("Home", LocationType::HomeLocation),
+        ("Desktop", LocationType::DesktopLocation),
+        ("Documents", LocationType::DocumentsLocation),
+        ("Download", LocationType::DownloadLocation),
+        ("Movies", LocationType::MoviesLocation),
+        ("Music", LocationType::MusicLocation),
+        ("Pictures", LocationType::PicturesLocation),
+        ("Applications", LocationType::ApplicationsLocation),
+        ("Fonts", LocationType::FontsLocation),
+        ("Runtime", LocationType::RuntimeLocation),
+        ("Temp", LocationType::TempLocation),
+        ("Generic Data", LocationType::GenericDataLocation),
+        ("App Data", LocationType::AppDataLocation),
+        ("App Local Data", LocationType::AppLocalDataLocation),
+        ("Generic Cache", LocationType::GenericCacheLocation),
+        ("App Cache", LocationType::AppCacheLocation),
+        ("Config", LocationType::ConfigLocation),
+        ("Generic Config", LocationType::GenericConfigLocation),
+        ("App Config", LocationType::AppConfigLocation),
     ];
 
     let sl = StandardPaths::new("app", "org");

--- a/examples/locate.rs
+++ b/examples/locate.rs
@@ -1,11 +1,7 @@
-extern crate argparse;
-extern crate standard_paths;
-
 use argparse::{ArgumentParser, Store, StoreTrue};
-use standard_paths::LocateOption::*;
-use standard_paths::LocationType::*;
-use standard_paths::*;
 use std::process;
+
+use standard_paths::*;
 
 fn main() {
     let mut app_name = String::new();
@@ -43,25 +39,25 @@ fn main() {
     }
 
     let location = match location.as_str() {
-        "HomeLocation" => HomeLocation,
-        "DesktopLocation" => DesktopLocation,
-        "DocumentsLocation" => DocumentsLocation,
-        "DownloadLocation" => DownloadLocation,
-        "MoviesLocation" => MoviesLocation,
-        "MusicLocation" => MusicLocation,
-        "PicturesLocation" => PicturesLocation,
-        "ApplicationsLocation" => ApplicationsLocation,
-        "FontsLocation" => FontsLocation,
-        "RuntimeLocation" => RuntimeLocation,
-        "TempLocation" => TempLocation,
-        "GenericDataLocation" => GenericDataLocation,
-        "AppDataLocation" => AppDataLocation,
-        "AppLocalDataLocation" => AppLocalDataLocation,
-        "GenericCacheLocation" => GenericCacheLocation,
-        "AppCacheLocation" => AppCacheLocation,
-        "ConfigLocation" => ConfigLocation,
-        "GenericConfigLocation" => GenericConfigLocation,
-        "AppConfigLocation" => AppConfigLocation,
+        "HomeLocation" => LocationType::HomeLocation,
+        "DesktopLocation" => LocationType::DesktopLocation,
+        "DocumentsLocation" => LocationType::DocumentsLocation,
+        "DownloadLocation" => LocationType::DownloadLocation,
+        "MoviesLocation" => LocationType::MoviesLocation,
+        "MusicLocation" => LocationType::MusicLocation,
+        "PicturesLocation" => LocationType::PicturesLocation,
+        "ApplicationsLocation" => LocationType::ApplicationsLocation,
+        "FontsLocation" => LocationType::FontsLocation,
+        "RuntimeLocation" => LocationType::RuntimeLocation,
+        "TempLocation" => LocationType::TempLocation,
+        "GenericDataLocation" => LocationType::GenericDataLocation,
+        "AppDataLocation" => LocationType::AppDataLocation,
+        "AppLocalDataLocation" => LocationType::AppLocalDataLocation,
+        "GenericCacheLocation" => LocationType::GenericCacheLocation,
+        "AppCacheLocation" => LocationType::AppCacheLocation,
+        "ConfigLocation" => LocationType::ConfigLocation,
+        "GenericConfigLocation" => LocationType::GenericConfigLocation,
+        "AppConfigLocation" => LocationType::AppConfigLocation,
         _ => {
             eprintln!(
                 "Bad location type '{}', see the documentation for valid values",
@@ -72,9 +68,9 @@ fn main() {
     };
 
     let option = match option.as_str() {
-        "LocateBoth" => LocateBoth,
-        "LocateFile" => LocateFile,
-        "LocateDirectory" => LocateDirectory,
+        "LocateBoth" => LocateOption::LocateBoth,
+        "LocateFile" => LocateOption::LocateFile,
+        "LocateDirectory" => LocateOption::LocateDirectory,
         _ => {
             eprintln!(
                 "Bad locate option '{}', see the documentation for valid values",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! A Rust library providing methods for accessing standard paths
 //! on the local filesystem (config, cache, user directories and etc.).
 //!
-//! It's a port of [QStandardPaths](https://doc.qt.io/qt-5/qstandardpaths.html)
+//! It's a port of [`QStandardPaths`](https://doc.qt.io/qt-5/qstandardpaths.html)
 //! class of the Qt framework.
 //!
 //! ### Usage
@@ -20,6 +20,7 @@
 //! ```
 
 #![warn(missing_docs)]
+#![warn(clippy::doc_markdown)]
 
 #[cfg(target_os = "linux")]
 mod linux;
@@ -40,8 +41,8 @@ use std::path::{Path, PathBuf};
 /// Enumerates the standard location type.
 ///
 /// Is used to call
-/// [StandardPaths::writable location](struct.StandardPaths.html#method.writable_location) and
-/// [StandardPaths::find_executable_in_paths](struct.StandardPaths.html#method.find_executable_in_paths).
+/// [`StandardPaths::writable_location`] and
+/// [`StandardPaths::find_executable_in_paths`].
 ///
 /// Some of the values are used to acquire user-specific paths,
 /// some are application-specific and some are system-wide.
@@ -79,8 +80,7 @@ pub enum LocationType {
     /// The directory for the runtime communication files (like Unix local sockets).
     ///
     /// This is a generic value. It could returns
-    /// [None](https://doc.rust-lang.org/std/option/enum.Option.html#variant.None)
-    /// on some systems.
+    /// [`None`] on some systems.
     RuntimeLocation,
     /// A directory for storing temporary files.
     ///
@@ -99,13 +99,12 @@ pub enum LocationType {
     ///
     /// This is a Windows-specific value.
     /// On all other platforms, it returns the same value as
-    /// [AppDataLocation](enum.LocationType.html#variant.AppDataLocation).
+    /// [`AppDataLocation`].
     AppLocalDataLocation,
     /// The directory for the user-specific cached data shared across applications.
     ///
     /// This is a generic value. It could returns
-    /// [None](https://doc.rust-lang.org/std/option/enum.Option.html#variant.None)
-    /// from the appropriate methods if the system has no concept of shared cache.
+    /// [`None`] from the appropriate methods if the system has no concept of shared cache.
     GenericCacheLocation,
     /// The user-specific cached data directory.
     ///
@@ -129,8 +128,8 @@ pub enum LocationType {
 /// Enumerates the locate option type.
 ///
 /// Is used to call
-/// [StandardPaths::locate location](struct.StandardPaths.html#method.locate) and
-/// [StandardPaths::locate_all](struct.StandardPaths.html#method.locate_all).
+/// [`StandardPaths::locate`] and
+/// [`StandardPaths::locate_all`].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LocateOption {
     /// Locate both files and directories (traversing symbolic links).
@@ -150,7 +149,7 @@ pub struct StandardPaths {
 }
 
 impl Default for StandardPaths {
-    /// Constructs a new `StandardPaths` with the application name
+    /// Constructs a new [`StandardPaths`] with the application name
     /// derived from the `CARGO_PKG_NAME` variable.
     fn default() -> StandardPaths {
         StandardPaths {
@@ -164,7 +163,7 @@ impl Default for StandardPaths {
 }
 
 impl StandardPaths {
-    /// Constructs a new `StandardPaths` with the provided `app` and `organization` names.
+    /// Constructs a new [`StandardPaths`] with the provided `app` and `organization` names.
     pub fn new<S>(app: S, organization: S) -> StandardPaths
     where
         S: Into<String>,
@@ -180,7 +179,7 @@ impl StandardPaths {
     /// For example `~/.config` -> `~/.config/org/app`.
     ///
     /// # Arguments
-    /// * `path` - a mutable `PathBuf` to which the app suffix should be appended.
+    /// * `path` - a mutable [`PathBuf`] to which the app suffix should be appended.
     fn append_organization_and_app(&self, path: &mut PathBuf) {
         if !self.org_name.is_empty() {
             path.push(&self.org_name);
@@ -194,8 +193,7 @@ impl StandardPaths {
     ///
     /// Note: the returned path can be a directory that does not exist.
     ///
-    /// Returns [Error](https://doc.rust-lang.org/std/io/struct.Error.html)
-    /// if the location cannot be determined.
+    /// Returns [`Error`] if the location cannot be determined.
     ///
     /// # Arguments
     /// * `location` - location type.
@@ -209,9 +207,8 @@ impl StandardPaths {
     /// [self.writable location](struct.StandardPaths.html#method.writable_location)
     /// if it can be determined.
     ///
-    /// Returns [Error](https://doc.rust-lang.org/std/io/struct.Error.html)
-    /// if the locations cannot be determined or an empty vector if no locations
-    /// for the provided type are defined.
+    /// Returns [`Error`] if the locations cannot be determined or
+    /// an empty vector if no locations for the provided type are defined.
     ///
     /// # Arguments
     /// * `location` - location type.
@@ -224,15 +221,14 @@ impl StandardPaths {
     /// It also could be used to check a path to be an executable.
     ///
     /// Internally it calls the
-    /// [self.find_executable_in_paths](struct.StandardPaths.html#method.find_executable_in_paths)
+    /// [`self.find_executable_in_paths`]
     /// method with the system path as the `paths` argument. On most operating systems
     /// the system path is determined by the `PATH` environment variable.
     ///
     /// Note: on Windows the executable extensions from the `PATHEXT` environment variable
     /// are automatically appended to the `name` if it doesn't contain any extension.
     ///
-    /// Returns [None](https://doc.rust-lang.org/std/option/enum.Option.html#variant.None)
-    /// if no executables are found or if the provided path is not executable.
+    /// Returns [`None`] if no executables are found or if the provided path is not executable.
     ///
     /// # Arguments
     /// * `name` - the name of the searched executable or an absolute path
@@ -255,8 +251,7 @@ impl StandardPaths {
     /// Note: on Windows the executable extensions from the `PATHEXT` environment variable
     /// are automatically appended to the `name` if it doesn't contain any extension.
     ///
-    /// Returns [None](https://doc.rust-lang.org/std/option/enum.Option.html#variant.None)
-    /// if no executables are found or if the provided path is not executable.
+    /// Returns [`None`] if no executables are found or if the provided path is not executable.
     ///
     /// # Arguments
     /// * `name` - the name of the searched executable or an absolute path
@@ -274,10 +269,8 @@ impl StandardPaths {
     ///
     /// Returns a full path to the first file or directory found.
     ///
-    /// Returns [Error](https://doc.rust-lang.org/std/io/struct.Error.html)
-    /// if accessing the `location` failed or
-    /// [None](https://doc.rust-lang.org/std/option/enum.Option.html#variant.None)
-    /// if no such file or directory can be found.
+    /// Returns [`Error`] if accessing the `location` failed or
+    /// [`None`] if no such file or directory can be found.
     ///
     /// # Arguments
     /// * `location` - the location type where to search.
@@ -320,10 +313,8 @@ impl StandardPaths {
     ///
     /// Returns a vector of full paths to the all files or directories found.
     ///
-    /// Returns [Error](https://doc.rust-lang.org/std/io/struct.Error.html)
-    /// if accessing the `location` failed or
-    /// [None](https://doc.rust-lang.org/std/option/enum.Option.html#variant.None)
-    /// if no such files or directories can be found.
+    /// Returns [`Error`] if accessing the `location` failed or
+    /// [`None`] if no such files or directories can be found.
     ///
     /// # Arguments
     /// * `location` - the location type where to search.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@
 //! }
 //! ```
 
+#![warn(missing_docs)]
+
 #[cfg(target_os = "linux")]
 mod linux;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,6 @@
 //! }
 //! ```
 
-#![allow(deprecated)] // Do not warn about deprecated std::env::home_dir
-
 #[cfg(target_os = "linux")]
 mod linux;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ use std::path::{Path, PathBuf};
 ///
 /// Some of the values are used to acquire user-specific paths,
 /// some are application-specific and some are system-wide.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LocationType {
     /// The user's home directory.
     ///
@@ -131,7 +131,7 @@ pub enum LocationType {
 /// Is used to call
 /// [StandardPaths::locate location](struct.StandardPaths.html#method.locate) and
 /// [StandardPaths::locate_all](struct.StandardPaths.html#method.locate_all).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LocateOption {
     /// Locate both files and directories (traversing symbolic links).
     LocateBoth,

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -63,8 +63,7 @@ fn xdg_data_dirs() -> Vec<PathBuf> {
 
 impl StandardPaths {
     #[inline]
-    #[doc(hidden)]
-    pub fn writable_location_impl(&self, location: LocationType) -> Result<PathBuf, Error> {
+    pub(super) fn writable_location_impl(&self, location: LocationType) -> Result<PathBuf, Error> {
         match location {
             LocationType::HomeLocation => home::home_dir().ok_or_else(StandardPaths::home_dir_err),
             LocationType::TempLocation => Ok(env::temp_dir()),
@@ -226,8 +225,10 @@ impl StandardPaths {
     }
 
     #[inline]
-    #[doc(hidden)]
-    pub fn standard_locations_impl(&self, location: LocationType) -> Result<Vec<PathBuf>, Error> {
+    pub(super) fn standard_locations_impl(
+        &self,
+        location: LocationType,
+    ) -> Result<Vec<PathBuf>, Error> {
         let mut res: Vec<PathBuf> = match location {
             LocationType::ConfigLocation | LocationType::GenericConfigLocation => xdg_config_dirs(),
             LocationType::AppConfigLocation => {
@@ -275,7 +276,7 @@ impl StandardPaths {
 }
 
 /// Detect if `path` is an executable based on its rights
-pub fn is_executable<P>(path: P) -> bool
+fn is_executable<P>(path: P) -> bool
 where
     P: Into<PathBuf>,
 {
@@ -289,8 +290,7 @@ where
 const EXTENSIONS: [&str; 3] = ["bin", "run", "sh"];
 
 #[inline]
-#[doc(hidden)]
-pub fn find_executable_in_paths_impl<S, P>(name: S, paths: P) -> Option<Vec<PathBuf>>
+pub(super) fn find_executable_in_paths_impl<S, P>(name: S, paths: P) -> Option<Vec<PathBuf>>
 where
     S: Into<String>,
     P: AsRef<Vec<PathBuf>>,

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,17 +1,13 @@
-extern crate users;
+use std::{
+    collections::HashMap,
+    env, fs,
+    io::{BufRead, BufReader, Error, ErrorKind},
+    os::{linux::fs::MetadataExt, unix::fs::PermissionsExt},
+    path::PathBuf,
+};
+use users::{get_current_uid, get_user_by_uid};
 
-use self::users::{get_current_uid, get_user_by_uid};
-use std::collections::HashMap;
-use std::env;
-use std::fs;
-use std::io::prelude::*;
-use std::io::{BufReader, Error, ErrorKind};
-use std::os::linux::fs::MetadataExt;
-use std::os::unix::fs::PermissionsExt;
-use std::path::PathBuf;
-
-use LocationType;
-use StandardPaths;
+use crate::{LocationType, StandardPaths};
 
 macro_rules! get_var_or_home {
     ($var_name:expr, $($sub_dirs:expr),*) => {

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -13,7 +13,7 @@ macro_rules! get_var_or_home {
     ($var_name:expr, $($sub_dirs:expr),*) => {
         match env::var($var_name) {
             Ok(path) => PathBuf::from(path),
-            _ => match env::home_dir() {
+            _ => match home::home_dir() {
                 Some(mut path) => {
                     $(
                         path.push($sub_dirs);
@@ -66,7 +66,7 @@ impl StandardPaths {
     #[doc(hidden)]
     pub fn writable_location_impl(&self, location: LocationType) -> Result<PathBuf, Error> {
         match location {
-            LocationType::HomeLocation => env::home_dir().ok_or_else(StandardPaths::home_dir_err),
+            LocationType::HomeLocation => home::home_dir().ok_or_else(StandardPaths::home_dir_err),
             LocationType::TempLocation => Ok(env::temp_dir()),
             LocationType::AppCacheLocation | LocationType::GenericCacheLocation => {
                 // http://standards.freedesktop.org/basedir-spec/basedir-spec-0.6.html
@@ -195,7 +195,7 @@ impl StandardPaths {
                 if lines.contains_key(key) {
                     let value = &lines[key];
                     if value.starts_with("$HOME") {
-                        let mut path = match env::home_dir() {
+                        let mut path = match home::home_dir() {
                             Some(path) => path,
                             _ => return Err(StandardPaths::home_dir_err()),
                         };
@@ -215,7 +215,7 @@ impl StandardPaths {
                     LocationType::DownloadLocation => "Downloads",
                     _ => return Err(Error::new(ErrorKind::Other, "Unexpected error")),
                 };
-                let mut path = match env::home_dir() {
+                let mut path = match home::home_dir() {
                     Some(path) => path,
                     _ => return Err(StandardPaths::home_dir_err()),
                 };
@@ -256,7 +256,7 @@ impl StandardPaths {
                 dirs
             }
 
-            LocationType::FontsLocation => match env::home_dir() {
+            LocationType::FontsLocation => match home::home_dir() {
                 Some(mut path) => {
                     path.push(".fonts");
                     vec![path]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -193,7 +193,7 @@ impl StandardPaths {
             }
 
             LocationType::RuntimeLocation | LocationType::HomeLocation => {
-                env::home_dir().ok_or_else(StandardPaths::home_dir_err)
+                home::home_dir().ok_or_else(StandardPaths::home_dir_err)
             }
 
             LocationType::TempLocation => {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -118,7 +118,7 @@ const FOLDERID_ProgramData: GUID = GUID {
 struct SafePwstr(PWSTR);
 
 impl SafePwstr {
-    pub fn new() -> Self {
+    fn new() -> Self {
         SafePwstr(ptr::null_mut())
     }
 }
@@ -170,8 +170,7 @@ macro_rules! sh_get_known_folder_path {
 
 impl StandardPaths {
     #[inline]
-    #[doc(hidden)]
-    pub fn writable_location_impl(&self, location: LocationType) -> Result<PathBuf, Error> {
+    pub(super) fn writable_location_impl(&self, location: LocationType) -> Result<PathBuf, Error> {
         match location {
             LocationType::DownloadLocation => {
                 sh_get_known_folder_path!(FOLDERID_Downloads, path, { Ok(path) }, {
@@ -245,8 +244,10 @@ impl StandardPaths {
     }
 
     #[inline]
-    #[doc(hidden)]
-    pub fn standard_locations_impl(&self, location: LocationType) -> Result<Vec<PathBuf>, Error> {
+    pub(super) fn standard_locations_impl(
+        &self,
+        location: LocationType,
+    ) -> Result<Vec<PathBuf>, Error> {
         let mut dirs = Vec::new();
         let path = self.writable_location(location)?;
         dirs.push(path);
@@ -300,8 +301,7 @@ where
 }
 
 #[inline]
-#[doc(hidden)]
-pub fn find_executable_in_paths_impl<S, P>(name: S, paths: P) -> Option<Vec<PathBuf>>
+pub(super) fn find_executable_in_paths_impl<S, P>(name: S, paths: P) -> Option<Vec<PathBuf>>
 where
     S: Into<String>,
     P: AsRef<Vec<PathBuf>>,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -251,7 +251,7 @@ impl StandardPaths {
     #[doc(hidden)]
     pub fn standard_locations_impl(&self, location: LocationType) -> Result<Vec<PathBuf>, Error> {
         let mut dirs = Vec::new();
-        let path = self.writable_location(location.clone())?;
+        let path = self.writable_location(location)?;
         dirs.push(path);
         if location == ConfigLocation
             || location == AppConfigLocation

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -16,7 +16,7 @@ use winapi::{
 
 use crate::{LocationType, StandardPaths};
 
-/// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Desktop
+/// [`FOLDERID_Desktop`](https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Desktop)
 #[allow(non_upper_case_globals)]
 const FOLDERID_Desktop: GUID = GUID {
     Data1: 0xB4BFCC3A,
@@ -25,7 +25,7 @@ const FOLDERID_Desktop: GUID = GUID {
     Data4: [0xB0, 0x29, 0x7F, 0xE9, 0x9A, 0x87, 0xC6, 0x41],
 };
 
-/// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Documents
+/// [`FOLDERID_Documents`](https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Documents)
 #[allow(non_upper_case_globals)]
 const FOLDERID_Documents: GUID = GUID {
     Data1: 0xFDD39AD0,
@@ -34,7 +34,7 @@ const FOLDERID_Documents: GUID = GUID {
     Data4: [0xAD, 0xB4, 0x6C, 0x85, 0x48, 0x03, 0x69, 0xC7],
 };
 
-/// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Fonts
+/// [`FOLDERID_Fonts`](https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Fonts)
 #[allow(non_upper_case_globals)]
 const FOLDERID_Fonts: GUID = GUID {
     Data1: 0xFD228CB7,
@@ -43,7 +43,7 @@ const FOLDERID_Fonts: GUID = GUID {
     Data4: [0x86, 0x4C, 0x16, 0xF3, 0x91, 0x0A, 0xB8, 0xFE],
 };
 
-/// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Programs
+/// [`FOLDERID_Programs`](https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Programs)
 #[allow(non_upper_case_globals)]
 const FOLDERID_Programs: GUID = GUID {
     Data1: 0xA77F5D77,
@@ -52,7 +52,7 @@ const FOLDERID_Programs: GUID = GUID {
     Data4: [0xA6, 0xA2, 0xAB, 0xA6, 0x01, 0x05, 0x4A, 0x51],
 };
 
-/// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Music
+/// [`FOLDERID_Music`](https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Music)
 #[allow(non_upper_case_globals)]
 const FOLDERID_Music: GUID = GUID {
     Data1: 0x4BD8D571,
@@ -61,7 +61,7 @@ const FOLDERID_Music: GUID = GUID {
     Data4: [0xBE, 0x97, 0x42, 0x22, 0x20, 0x08, 0x0E, 0x43],
 };
 
-/// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Videos
+/// [`FOLDERID_Videos`](https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Videos)
 #[allow(non_upper_case_globals)]
 const FOLDERID_Videos: GUID = GUID {
     Data1: 0x18989B1D,
@@ -70,7 +70,7 @@ const FOLDERID_Videos: GUID = GUID {
     Data4: [0x84, 0x1C, 0xAB, 0x7C, 0x74, 0xE4, 0xDD, 0xFC],
 };
 
-/// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Pictures
+/// [`FOLDERID_Pictures`](https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Pictures)
 #[allow(non_upper_case_globals)]
 const FOLDERID_Pictures: GUID = GUID {
     Data1: 0x33E28130,
@@ -79,7 +79,7 @@ const FOLDERID_Pictures: GUID = GUID {
     Data4: [0x83, 0x5A, 0x98, 0x39, 0x5C, 0x3B, 0xC3, 0xBB],
 };
 
-/// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Downloads
+/// [`FOLDERID_Downloads`](https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_Downloads)
 #[allow(non_upper_case_globals)]
 const FOLDERID_Downloads: GUID = GUID {
     Data1: 0x374DE290,
@@ -88,7 +88,7 @@ const FOLDERID_Downloads: GUID = GUID {
     Data4: [0x91, 0x64, 0x39, 0xC4, 0x92, 0x5E, 0x46, 0x7B],
 };
 
-/// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_LocalAppData
+/// [`FOLDERID_LocalAppData`](https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_LocalAppData)
 #[allow(non_upper_case_globals)]
 const FOLDERID_LocalAppData: GUID = GUID {
     Data1: 0xF1B32785,
@@ -97,7 +97,7 @@ const FOLDERID_LocalAppData: GUID = GUID {
     Data4: [0x9D, 0x55, 0x7B, 0x8E, 0x7F, 0x15, 0x70, 0x91],
 };
 
-/// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_RoamingAppData
+/// [`FOLDERID_RoamingAppData`](https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_RoamingAppData)
 #[allow(non_upper_case_globals)]
 const FOLDERID_RoamingAppData: GUID = GUID {
     Data1: 0x3EB685DB,
@@ -106,7 +106,7 @@ const FOLDERID_RoamingAppData: GUID = GUID {
     Data4: [0xA0, 0x3A, 0xE3, 0xEF, 0x65, 0x72, 0x9F, 0x3D],
 };
 
-/// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_ProgramData
+/// [`FOLDERID_ProgramData`](https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_ProgramData)
 #[allow(non_upper_case_globals)]
 const FOLDERID_ProgramData: GUID = GUID {
     Data1: 0x62AB5D82,
@@ -284,7 +284,7 @@ impl StandardPaths {
 }
 
 /// Detect if `path` is an executable (based on
-/// [GetBinaryType](https://msdn.microsoft.com/ru-ru/library/windows/desktop/aa364819.aspx)).
+/// [`GetBinaryType`](https://msdn.microsoft.com/ru-ru/library/windows/desktop/aa364819.aspx)).
 fn is_executable<P>(path: P) -> bool
 where
     P: AsRef<OsStr>,


### PR DESCRIPTION
* I fixed comments in `folerid_generator` (was broken after `cargo fmt`). BTW, what is this example for?
* Enabled clippy checks on examples and fixed warnings.
* Implemented `Copy` on enums. Enum values that smaller then pointer are faster to pass by value.
* Upgraded to Rust 2021. The only thing that I had to change was modules inclusion.
* Use [home](https://docs.rs/home/0.5.3/home/index.html) crate (used even by Cargo!) instead of deprecated `std::env::home_dir()`.
* Hide extra `pub` functions.
* Fix markdown doc and enable `clippy::doc_markdown`.