### PR TITLE
Determine app_name at compile time for StandardPaths::default()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,10 +153,7 @@ impl Default for StandardPaths {
     /// derived from the `CARGO_PKG_NAME` variable.
     fn default() -> StandardPaths {
         StandardPaths {
-            app_name: match env::var("CARGO_PKG_NAME") {
-                Ok(name) => name,
-                _ => String::new(),
-            },
+            app_name: env!("CARGO_PKG_NAME").to_string(),
             org_name: String::new(),
         }
     }


### PR DESCRIPTION
Previously used function did it at runtime. I switched to the [env!](https://doc.rust-lang.org/std/macro.env.html) macro