### PR TITLE
Remove custom labels for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    labels:
-      - 'dependencies'
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
-    labels:
-      - 'github actions'


### PR DESCRIPTION
To avoid messages like this:
`The following labels could not be found: github actions.`