### PR TITLE
Remove `Default` for `StandardPaths`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,14 +149,25 @@ pub struct StandardPaths {
 }
 
 impl StandardPaths {
-    /// Constructs a new [`StandardPaths`] with the provided `app` and `organization` names.
-    pub fn new<S>(app: S, organization: S) -> StandardPaths
+    /// Constructs a new [`StandardPaths`] with the provided `app` and `org` names.
+    pub fn new<S>(app: S, org: S) -> StandardPaths
     where
         S: Into<String>,
     {
         StandardPaths {
             app_name: app.into(),
-            org_name: organization.into(),
+            org_name: org.into(),
+        }
+    }
+
+    /// Constructs a new [`StandardPaths`] with the provided `app` name and with an empty organization.
+    pub fn without_org<S>(app: S) -> StandardPaths
+    where
+        S: Into<String>,
+    {
+        StandardPaths {
+            app_name: app.into(),
+            org_name: Default::default(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,17 +148,6 @@ pub struct StandardPaths {
     org_name: String,
 }
 
-impl Default for StandardPaths {
-    /// Constructs a new [`StandardPaths`] with the application name
-    /// derived from the `CARGO_PKG_NAME` variable.
-    fn default() -> StandardPaths {
-        StandardPaths {
-            app_name: env!("CARGO_PKG_NAME").to_string(),
-            org_name: String::new(),
-        }
-    }
-}
-
 impl StandardPaths {
     /// Constructs a new [`StandardPaths`] with the provided `app` and `organization` names.
     pub fn new<S>(app: S, organization: S) -> StandardPaths


### PR DESCRIPTION
`CARGO_PKG_NAME` results in `standard_paths` if compiled as a dependency of another crate. Unfortunately, there is no way to obtain the main package name for a dependency.

So I removed the impl to avoid confusion. I would suggest to draft a new release after it.