### PR TITLE
Add the `default` macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,17 +43,15 @@ use std::path::{Path, PathBuf};
 ///
 /// ### Example
 /// ```
-/// use standard_paths::{LocationType, StandardPaths};
+/// use standard_paths::LocationType;
 ///
-/// fn main() {
-///     let sp = standard_paths::default!();
-///     println!("{:?}", sp.writable_location(LocationType::AppLocalDataLocation));
-/// }
+/// let sp = standard_paths::default!();
+/// println!("{:?}", sp.writable_location(LocationType::AppLocalDataLocation));
 /// ```
 #[macro_export]
 macro_rules! default {
     () => {
-        crate::StandardPaths::without_org(env!("CARGO_PKG_NAME"))
+        $crate::StandardPaths::without_org(env!("CARGO_PKG_NAME"))
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,25 @@ use std::env;
 use std::io::{Error, ErrorKind};
 use std::path::{Path, PathBuf};
 
+/// Constructs a new [`StandardPaths`] with the application name
+/// derived from the `CARGO_PKG_NAME` variable.
+///
+/// ### Example
+/// ```
+/// use standard_paths::{LocationType, StandardPaths};
+///
+/// fn main() {
+///     let sp = standard_paths::default!();
+///     println!("{:?}", sp.writable_location(LocationType::AppLocalDataLocation));
+/// }
+/// ```
+#[macro_export]
+macro_rules! default {
+    () => {
+        crate::StandardPaths::without_org(env!("CARGO_PKG_NAME"))
+    };
+}
+
 /// Enumerates the standard location type.
 ///
 /// Is used to call

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,11 +45,11 @@ use std::path::{Path, PathBuf};
 /// ```
 /// use standard_paths::LocationType;
 ///
-/// let sp = standard_paths::default!();
+/// let sp = standard_paths::default_paths!();
 /// println!("{:?}", sp.writable_location(LocationType::AppLocalDataLocation));
 /// ```
 #[macro_export]
-macro_rules! default {
+macro_rules! default_paths {
     () => {
         $crate::StandardPaths::without_org(env!("CARGO_PKG_NAME"))
     };


### PR DESCRIPTION
This is an alternative to `StandardPaths::default` that could be used in dependent crates to fetch the app name from `CARGO_PKG_NAME`